### PR TITLE
Dev

### DIFF
--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -12,15 +12,6 @@ type PageProps = {
     }
 }
 
-// export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-//     const product = await getProductById(params.id)
-//     return {
-//         title: product ? product.nombre : 'Producto no encontrado',
-//     }
-// }
-
-
-
 export default async function ProductDetail({ params }: PageProps) {
 
     const { id } = params

--- a/app/product/[id]/page.tsx
+++ b/app/product/[id]/page.tsx
@@ -3,13 +3,29 @@ import { Product } from '@/types/product'
 import productsData from '@/data/mock-products.json'
 import Link from 'next/link'
 import Image from 'next/image'
+import type { Metadata } from 'next'
+import { getProductById } from '../../../lib/getProductById.ts'
 
-interface Params {
-    params: { id: string }
+type PageProps = {
+    params: {
+        id: string
+    }
 }
 
-export default function ProductDetail({ params }: Params) {
-    const product = (productsData as Product[]).find(p => p.id === params.id)
+// export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+//     const product = await getProductById(params.id)
+//     return {
+//         title: product ? product.nombre : 'Producto no encontrado',
+//     }
+// }
+
+
+
+export default async function ProductDetail({ params }: PageProps) {
+
+    const { id } = params
+
+    const product = await getProductById(id)
 
     if (!product) return notFound()
 

--- a/lib/getProductById.ts.ts
+++ b/lib/getProductById.ts.ts
@@ -1,0 +1,7 @@
+import { Product } from '@/types/product'
+
+export async function getProductById(id: string): Promise<Product | undefined> {
+    const productsData = await import('@/data/mock-products.json')
+    const products = productsData.default as Product[]
+    return products.find((p) => p.id === id)
+}


### PR DESCRIPTION
⚠️ Nota técnica: En desarrollo (next dev) aparece un warning relacionado con params.id en rutas dinámicas (/product/[id]). Este comportamiento es conocido en Next.js 15 y no afecta el funcionamiento ni se presenta en producción. En producción (Vercel), la app funciona correctamente sin advertencias.